### PR TITLE
refactor: update agent merge order

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -146,7 +146,7 @@ export const BeadsPlugin: Plugin = async ({ client, $ }) => {
 
     config: async (config) => {
       config.command = { ...config.command, ...commands };
-      config.agent = { ...config.agent, ...agents };
+      config.agent = { ...agents, ...config.agent };
     },
   };
 };


### PR DESCRIPTION
Trying to override the model used for beads-task-agent in opencode.json wasnt working.

By flipping the merge order settings in opencode.json now take precedence