### PR TITLE
Relax bd JSON guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Changed
+
+- Updated injected CLI guidance to show default `bd` output, using `--json` when structured output makes a task easier or more reliable.
+
 ## [0.6.0]
 
 ### Changed

--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -94,20 +94,20 @@ const BEADS_CLI_USAGE = `## CLI Usage
 Instead, use the \`bash\` tool for all beads operations:
 
 - \`bd init [prefix]\` - Initialize beads
-- \`bd ready --json\` - List ready tasks
-- \`bd show <id> --json\` - Show task details
-- \`bd create "title" -t bug|feature|task -p 0-4 --json\` - Create issue
-- \`bd update <id> --status in_progress --json\` - Update status
-- \`bd close <id> --reason "message" --json\` - Close issue
-- \`bd reopen <id> --json\` - Reopen issue
-- \`bd dep add <from> <to> --type blocks|discovered-from --json\` - Add dependency
-- \`bd list --status open --json\` - List issues
-- \`bd blocked --json\` - Show blocked issues
-- \`bd stats --json\` - Show statistics
+- \`bd ready\` - List ready tasks
+- \`bd show <id>\` - Show task details
+- \`bd create "title" -t bug|feature|task -p 0-4\` - Create issue
+- \`bd update <id> --status in_progress\` - Update status
+- \`bd close <id> --reason "message"\` - Close issue
+- \`bd reopen <id>\` - Reopen issue
+- \`bd dep add <from> <to> --type blocks|discovered-from\` - Add dependency
+- \`bd list --status open\` - List issues
+- \`bd blocked\` - Show blocked issues
+- \`bd stats\` - Show statistics
 
 If a tool is not listed above, try \`bd <tool> --help\`.
 
-Always use \`--json\` flag for structured output.`;
+Use the default command output unless \`--json\` would make a task easier or more reliable. If you parse command output, distinguish parsing errors from command failures.`;
 
 const BEADS_SUBAGENT_CONTEXT = `## Subagent Context
 


### PR DESCRIPTION
## Summary
- Remove `--json` from default injected `bd` command examples
- Update guidance to use `--json` when structured output makes a task easier or more reliable
- Document the change in the changelog

## Validation
- `bun run typecheck` *(fails: existing Docusaurus reference files are missing dependencies / have an unrelated duplicate property issue)*

Closes #64
