### PR TITLE
fix: update sync paths for upstream beads repo restructure

### DIFF
--- a/scripts/sync-beads.sh
+++ b/scripts/sync-beads.sh
@@ -18,10 +18,10 @@ trap 'rm -rf "$TEMP_DIR"' EXIT
 git clone --depth 1 --branch "$BEADS_VERSION" --quiet "$BEADS_REPO" "$TEMP_DIR/beads"
 
 rm -rf "$PLUGIN_DIR/vendor/commands"
-cp -r "$TEMP_DIR/beads/claude-plugin/commands" "$PLUGIN_DIR/vendor/commands"
+cp -r "$TEMP_DIR/beads/plugins/beads/skills/beads/commands" "$PLUGIN_DIR/vendor/commands"
 
 mkdir -p "$PLUGIN_DIR/vendor/agents"
-cp "$TEMP_DIR/beads/claude-plugin/agents/task-agent.md" "$PLUGIN_DIR/vendor/agents/"
+cp "$TEMP_DIR/beads/plugins/beads/agents/task-agent.md" "$PLUGIN_DIR/vendor/agents/"
 
 if [ -z "$(git -C "$PLUGIN_DIR" status --porcelain)" ]; then
   echo "No changes detected"


### PR DESCRIPTION
The beads repo moved its plugin layout out of claude-plugin/. Commands
now live at plugins/beads/skills/beads/commands and the task agent at
plugins/beads/agents/task-agent.md, which broke the daily sync workflow
with "cp: cannot stat .../claude-plugin/commands: No such file or
directory".

Point the copy commands at the new upstream paths.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D9N7zbYGzNBkyy8qes8bQo